### PR TITLE
feat: add panic monitor with live map integration

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,2 +1,13 @@
 /// <reference types="vite/client" />
 /// <reference types="tailwindcss" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE?: string
+  readonly VITE_API_BASE_URL?: string
+  readonly VITE_PANIC_BASE?: string
+  readonly VITE_MAP_STYLE?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@
         <RouterView />
       </v-main>
     </v-layout>
+    <ToastHost />
   </v-app>
 </template>
 
@@ -17,6 +18,7 @@ import { onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 import LocaleNavigation from '@/components/LocaleNavigation.vue'
+import ToastHost from '@/components/ToastHost.vue'
 import { detectLocale } from '@/utils/localeDetection'
 
 const { locale } = useI18n()

--- a/src/components/IncidentMap.vue
+++ b/src/components/IncidentMap.vue
@@ -1,0 +1,532 @@
+<template>
+  <div ref="mapContainer" class="incident-map">
+    <div v-if="!ready" class="map-loader">
+      <span class="loading loading-spinner loading-md" />
+      <span>{{ $t('monitor.loading') }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { loadMapLibre, type MapInstance, type MapLibreModule } from '@/lib/maplibre'
+import type { Incident, Waypoint } from '@/types/panic'
+
+const props = defineProps({
+  incidents: {
+    type: Array as () => Incident[],
+    default: () => [],
+  },
+  selectedIncidentId: {
+    type: String,
+    default: null,
+  },
+  highlightIncidentId: {
+    type: String,
+    default: null,
+  },
+  waypoints: {
+    type: Array as () => Waypoint[],
+    default: () => [],
+  },
+})
+
+const emit = defineEmits<{
+  (event: 'select', incidentId: string | null): void
+  (event: 'bbox-change', bbox: [number, number, number, number]): void
+  (event: 'ready', map: MapInstance): void
+}>()
+
+const mapContainer = ref<HTMLDivElement | null>(null)
+const map = ref<MapInstance | null>(null)
+const ready = ref(false)
+
+let maplibre: MapLibreModule | null = null
+let highlightTimer: ReturnType<typeof setTimeout> | null = null
+
+const INCIDENT_SOURCE = 'incident-source'
+const CLUSTER_LAYER = 'incident-clusters'
+const CLUSTER_COUNT_LAYER = 'incident-cluster-count'
+const POINT_LAYER = 'incident-points'
+const SELECTED_LAYER = 'incident-selected'
+const HIGHLIGHT_LAYER = 'incident-highlight'
+const WAYPOINT_SOURCE = 'waypoint-source'
+const WAYPOINT_LAYER = 'waypoint-circles'
+
+const featureCollection = computed(() => buildIncidentCollection(props.incidents))
+const waypointCollection = computed(() => buildWaypointCollection(props.waypoints))
+
+onMounted(async () => {
+  if (!mapContainer.value) {
+    return
+  }
+
+  try {
+    maplibre = await loadMapLibre()
+  } catch (error) {
+    console.error('[panic] Failed to load MapLibre', error)
+    return
+  }
+
+  const style = import.meta.env.VITE_MAP_STYLE || 'https://demotiles.maplibre.org/style.json'
+  map.value = new maplibre.Map({
+    container: mapContainer.value,
+    style,
+    center: [28.188, -25.5],
+    zoom: 6.5,
+    minZoom: 3,
+    maxZoom: 18,
+  })
+
+  map.value.addControl(new maplibre.NavigationControl({ showCompass: false }), 'top-right')
+
+  map.value.on('load', () => {
+    setupSources()
+    setupLayers()
+    bindInteractions()
+    ready.value = true
+    updateIncidents()
+    updateWaypoints()
+    updateSelected(props.selectedIncidentId)
+    updateHighlight(props.highlightIncidentId)
+    emitBounds()
+    emit('ready', map.value as MapInstance)
+  })
+
+  map.value.on('moveend', emitBounds)
+})
+
+onBeforeUnmount(() => {
+  if (highlightTimer) {
+    clearTimeout(highlightTimer)
+    highlightTimer = null
+  }
+  map.value?.remove()
+  map.value = null
+})
+
+watch(
+  () => featureCollection.value,
+  () => {
+    updateIncidents()
+  },
+  { deep: true },
+)
+
+watch(
+  () => props.selectedIncidentId,
+  (id) => {
+    updateSelected(id)
+    if (!id) {
+      return
+    }
+
+    const incident = props.incidents.find((item) => item.id === id)
+    if (incident) {
+      flyToIncident(incident)
+    }
+  },
+)
+
+watch(
+  () => props.highlightIncidentId,
+  (id) => {
+    if (id) {
+      flashIncident(id)
+    }
+  },
+)
+
+watch(
+  () => waypointCollection.value,
+  () => updateWaypoints(),
+  { deep: true },
+)
+
+function setupSources() {
+  if (!map.value || !maplibre) {
+    return
+  }
+
+  if (!map.value.getSource(INCIDENT_SOURCE)) {
+    map.value.addSource(INCIDENT_SOURCE, {
+      type: 'geojson',
+      data: featureCollection.value,
+      cluster: true,
+      clusterRadius: 60,
+      clusterMaxZoom: 14,
+    })
+  }
+
+  if (!map.value.getSource(WAYPOINT_SOURCE)) {
+    map.value.addSource(WAYPOINT_SOURCE, {
+      type: 'geojson',
+      data: waypointCollection.value,
+    })
+  }
+}
+
+function setupLayers() {
+  if (!map.value) {
+    return
+  }
+
+  if (!map.value.getLayer(CLUSTER_LAYER)) {
+    map.value.addLayer({
+      id: CLUSTER_LAYER,
+      type: 'circle',
+      source: INCIDENT_SOURCE,
+      filter: ['has', 'point_count'],
+      paint: {
+        'circle-color': [
+          'step',
+          ['get', 'point_count'],
+          '#1d4ed8',
+          5,
+          '#2563eb',
+          15,
+          '#1e3a8a',
+        ],
+        'circle-radius': [
+          'step',
+          ['get', 'point_count'],
+          14,
+          5,
+          18,
+          15,
+          22,
+        ],
+        'circle-opacity': 0.85,
+      },
+    })
+  }
+
+  if (!map.value.getLayer(CLUSTER_COUNT_LAYER)) {
+    map.value.addLayer({
+      id: CLUSTER_COUNT_LAYER,
+      type: 'symbol',
+      source: INCIDENT_SOURCE,
+      filter: ['has', 'point_count'],
+      layout: {
+        'text-field': '{point_count_abbreviated}',
+        'text-font': ['Open Sans Bold', 'Arial Unicode MS Bold'],
+        'text-size': 12,
+      },
+      paint: {
+        'text-color': '#ffffff',
+      },
+    })
+  }
+
+  if (!map.value.getLayer(POINT_LAYER)) {
+    map.value.addLayer({
+      id: POINT_LAYER,
+      type: 'circle',
+      source: INCIDENT_SOURCE,
+      filter: ['!', ['has', 'point_count']],
+      paint: {
+        'circle-radius': 9,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#ffffff',
+        'circle-color': [
+          'match',
+          ['get', 'status'],
+          'resolved',
+          '#22c55e',
+          'acknowledged',
+          '#38bdf8',
+          'open',
+          '#f97316',
+          '#6366f1',
+        ],
+      },
+    })
+  }
+
+  if (!map.value.getLayer(SELECTED_LAYER)) {
+    map.value.addLayer({
+      id: SELECTED_LAYER,
+      type: 'circle',
+      source: INCIDENT_SOURCE,
+      filter: ['in', ['get', 'id'], ['literal', []]],
+      paint: {
+        'circle-radius': 16,
+        'circle-color': '#fbbf24',
+        'circle-opacity': 0.25,
+        'circle-stroke-color': '#f59e0b',
+        'circle-stroke-width': 2,
+      },
+    })
+  }
+
+  if (!map.value.getLayer(HIGHLIGHT_LAYER)) {
+    map.value.addLayer({
+      id: HIGHLIGHT_LAYER,
+      type: 'circle',
+      source: INCIDENT_SOURCE,
+      filter: ['in', ['get', 'id'], ['literal', []]],
+      paint: {
+        'circle-radius': 22,
+        'circle-color': '#fb923c',
+        'circle-opacity': 0.2,
+        'circle-stroke-color': '#f97316',
+        'circle-stroke-width': 1,
+      },
+    })
+  }
+
+  if (!map.value.getLayer(WAYPOINT_LAYER)) {
+    map.value.addLayer({
+      id: WAYPOINT_LAYER,
+      type: 'circle',
+      source: WAYPOINT_SOURCE,
+      paint: {
+        'circle-radius': [
+          'case',
+          ['has', 'radius'],
+          ['interpolate', ['linear'], ['zoom'], 8, 6, 16, 18],
+          8,
+        ],
+        'circle-color': ['coalesce', ['get', 'color'], '#3b82f6'],
+        'circle-opacity': 0.18,
+        'circle-stroke-color': ['coalesce', ['get', 'color'], '#1d4ed8'],
+        'circle-stroke-width': 2,
+      },
+    })
+  }
+}
+
+function bindInteractions() {
+  if (!map.value) {
+    return
+  }
+
+  map.value.on('click', CLUSTER_LAYER, (event: any) => {
+    const feature = event.features?.[0]
+    if (!feature) {
+      return
+    }
+
+    const clusterId = feature.properties?.cluster_id
+    const coordinates = feature.geometry?.coordinates
+    const source = map.value!.getSource(INCIDENT_SOURCE) as any
+    if (source?.getClusterExpansionZoom && clusterId != null) {
+      source.getClusterExpansionZoom(clusterId, (error: unknown, zoom: number) => {
+        if (error) {
+          return
+        }
+        map.value?.easeTo({ center: coordinates, zoom })
+      })
+    }
+  })
+
+  map.value.on('click', POINT_LAYER, (event: any) => {
+    const feature = event.features?.[0]
+    if (!feature) {
+      return
+    }
+    const id = feature.properties?.id
+    if (typeof id === 'string') {
+      emit('select', id)
+    }
+  })
+
+  map.value.on('mouseenter', POINT_LAYER, () => {
+    if (map.value) {
+      map.value.getCanvas().style.cursor = 'pointer'
+    }
+  })
+
+  map.value.on('mouseleave', POINT_LAYER, () => {
+    if (map.value) {
+      map.value.getCanvas().style.cursor = ''
+    }
+  })
+}
+
+function updateIncidents() {
+  if (!map.value) {
+    return
+  }
+
+  const source = map.value.getSource(INCIDENT_SOURCE) as any
+  if (source && typeof source.setData === 'function') {
+    source.setData(featureCollection.value)
+  }
+}
+
+function updateWaypoints() {
+  if (!map.value) {
+    return
+  }
+
+  const source = map.value.getSource(WAYPOINT_SOURCE) as any
+  if (source && typeof source.setData === 'function') {
+    source.setData(waypointCollection.value)
+  }
+}
+
+function updateSelected(incidentId: string | null) {
+  if (!map.value) {
+    return
+  }
+
+  const filter = incidentId ? ['==', ['get', 'id'], incidentId] : ['in', ['get', 'id'], ['literal', []]]
+  if (map.value.getLayer(SELECTED_LAYER)) {
+    map.value.setFilter(SELECTED_LAYER, filter)
+  }
+}
+
+function updateHighlight(incidentId: string | null) {
+  if (!map.value) {
+    return
+  }
+
+  const filter = incidentId ? ['==', ['get', 'id'], incidentId] : ['in', ['get', 'id'], ['literal', []]]
+  if (map.value.getLayer(HIGHLIGHT_LAYER)) {
+    map.value.setFilter(HIGHLIGHT_LAYER, filter)
+  }
+}
+
+function emitBounds() {
+  if (!map.value) {
+    return
+  }
+
+  const bounds = map.value.getBounds().toArray()
+  emit('bbox-change', [bounds[0][0], bounds[0][1], bounds[1][0], bounds[1][1]])
+}
+
+function flyToIncident(incident: Incident, zoom = 15) {
+  if (!map.value) {
+    return
+  }
+
+  map.value.flyTo({
+    center: [incident.location.longitude, incident.location.latitude],
+    zoom,
+    speed: 1.6,
+  })
+}
+
+function flashIncident(incidentId: string, duration = 1800) {
+  if (!map.value) {
+    return
+  }
+
+  updateHighlight(incidentId)
+  if (highlightTimer) {
+    clearTimeout(highlightTimer)
+  }
+
+  highlightTimer = setTimeout(() => {
+    updateHighlight(null)
+  }, duration)
+}
+
+function fitToIncidents() {
+  if (!map.value || props.incidents.length === 0) {
+    return
+  }
+
+  const coordinates = props.incidents.map((incident) => [
+    incident.location.longitude,
+    incident.location.latitude,
+  ])
+
+  const bounds = coordinates.reduce(
+    (acc, coord) => {
+      acc[0] = Math.min(acc[0], coord[0])
+      acc[1] = Math.min(acc[1], coord[1])
+      acc[2] = Math.max(acc[2], coord[0])
+      acc[3] = Math.max(acc[3], coord[1])
+      return acc
+    },
+    [Infinity, Infinity, -Infinity, -Infinity] as [number, number, number, number],
+  )
+
+  if (bounds[0] === Infinity) {
+    return
+  }
+
+  map.value.fitBounds([
+    [bounds[0], bounds[1]],
+    [bounds[2], bounds[3]],
+  ], {
+    padding: 60,
+    maxZoom: 15,
+  })
+}
+
+function buildIncidentCollection(incidents: Incident[]): GeoJSON.FeatureCollection<GeoJSON.Point> {
+  return {
+    type: 'FeatureCollection',
+    features: incidents
+      .filter((incident) => Number.isFinite(incident.location.longitude) && Number.isFinite(incident.location.latitude))
+      .map((incident) => ({
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [incident.location.longitude, incident.location.latitude],
+        },
+        properties: {
+          id: incident.id,
+          status: incident.status,
+          summary: incident.summary,
+          reportedAt: incident.reportedAt,
+        },
+      })),
+  }
+}
+
+function buildWaypointCollection(waypoints: Waypoint[]): GeoJSON.FeatureCollection<GeoJSON.Point> {
+  return {
+    type: 'FeatureCollection',
+    features: waypoints
+      .filter((waypoint) => Number.isFinite(waypoint.longitude) && Number.isFinite(waypoint.latitude))
+      .map((waypoint) => ({
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [waypoint.longitude, waypoint.latitude],
+        },
+        properties: {
+          id: waypoint.id,
+          name: waypoint.name,
+          radius: waypoint.radius,
+          color: waypoint.color,
+        },
+      })),
+  }
+}
+
+function resize() {
+  nextTick(() => {
+    map.value?.resize()
+  })
+}
+
+defineExpose({ flyToIncident, flashIncident, fitToIncidents, resize })
+</script>
+
+<style scoped>
+.incident-map {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.map-loader {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(16, 185, 129, 0.08));
+  color: var(--color-base-content, #1f2937);
+}
+</style>

--- a/src/components/LocaleNavigation.vue
+++ b/src/components/LocaleNavigation.vue
@@ -23,6 +23,14 @@
         :active="isRoute('/dashboard')"
       />
 
+      <v-list-item
+        :prepend-icon="'mdi-map-marker-alert'"
+        :title="t('app.monitor')"
+        :value="'monitor'"
+        :to="getLocalizedPath('/monitor')"
+        :active="isRoute('/monitor')"
+      />
+
       <!-- Demo Pages -->
       <v-list-item
         :prepend-icon="'mdi-translate'"

--- a/src/components/ToastHost.vue
+++ b/src/components/ToastHost.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="toast-container pointer-events-none">
+    <TransitionGroup name="toast">
+      <div
+        v-for="toast in toasts"
+        :key="toast.id"
+        class="toast pointer-events-auto"
+        :class="toastVariantClass(toast.variant)"
+        role="status"
+        aria-live="assertive"
+      >
+        <div class="toast-body">
+          <div class="toast-content">
+            <p v-if="toast.title" class="toast-title">{{ toast.title }}</p>
+            <p class="toast-message">{{ toast.message }}</p>
+          </div>
+          <div class="toast-actions">
+            <button
+              v-if="toast.action"
+              type="button"
+              class="btn btn-sm"
+              @click="handleAction(toast.id)"
+            >
+              {{ toast.action.label }}
+            </button>
+            <button type="button" class="btn btn-ghost btn-sm" @click="dismiss(toast.id)">
+              ×
+            </button>
+          </div>
+        </div>
+      </div>
+    </TransitionGroup>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useToasts } from '@/composables/useToasts'
+
+const { toasts, dismiss } = useToasts()
+
+function toastVariantClass(variant: string) {
+  switch (variant) {
+    case 'success':
+      return 'bg-success text-success-content'
+    case 'warning':
+      return 'bg-warning text-warning-content'
+    case 'error':
+      return 'bg-error text-error-content'
+    default:
+      return 'bg-info text-info-content'
+  }
+}
+
+function handleAction(id: string) {
+  const toast = toasts.value.find((item) => item.id === id)
+  toast?.action?.handler()
+  dismiss(id)
+}
+</script>
+
+<style scoped>
+.toast-container {
+  position: fixed;
+  inset: 1rem 1rem auto auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 60;
+}
+
+.toast-enter-from,
+.toast-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+.toast-enter-active,
+.toast-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.toast {
+  border-radius: 0.75rem;
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
+  padding: 0.75rem 1rem;
+  min-width: 18rem;
+  max-width: 24rem;
+}
+
+.toast-body {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.toast-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.toast-message {
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
+.toast-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+</style>

--- a/src/composables/useIncidentStream.ts
+++ b/src/composables/useIncidentStream.ts
@@ -1,0 +1,198 @@
+import { onBeforeUnmount, ref } from 'vue'
+import type { IncidentStreamEnvelope } from '@/types/panic'
+
+type StreamListener<T = unknown> = (event: StreamEvent<T>) => void
+
+type ListenerMap = Map<string, Set<StreamListener<any>>>
+
+interface StreamHandlers {
+  [event: string]: (event: MessageEvent<string>) => void
+}
+
+export interface StreamEvent<T = unknown> {
+  event: string
+  data: T
+  raw: MessageEvent<string>
+}
+
+export interface UseIncidentStreamOptions {
+  autoConnect?: boolean
+  immediateReconnect?: boolean
+}
+
+export interface UseIncidentStream {
+  readonly isConnected: ReturnType<typeof ref<boolean>>
+  readonly lastEvent: ReturnType<typeof ref<StreamEvent | null>>
+  readonly lastError: ReturnType<typeof ref<Event | null>>
+  connect: () => void
+  disconnect: () => void
+  on: <T = unknown>(eventName: string, listener: StreamListener<T>) => () => void
+}
+
+const STREAM_PATH = '/stream'
+
+export function useIncidentStream(options: UseIncidentStreamOptions = {}): UseIncidentStream {
+  const isConnected = ref(false)
+  const lastEvent = ref<StreamEvent | null>(null)
+  const lastError = ref<Event | null>(null)
+
+  const listeners: ListenerMap = new Map()
+  const handlers: StreamHandlers = {}
+
+  let eventSource: EventSource | null = null
+
+  function emitEvent<T = unknown>(eventName: string, rawEvent: MessageEvent<string>): void {
+    let parsed: unknown = rawEvent.data
+    if (rawEvent.data && typeof rawEvent.data === 'string') {
+      try {
+        parsed = JSON.parse(rawEvent.data)
+      } catch (error) {
+        parsed = rawEvent.data
+      }
+    }
+
+    const payload: StreamEvent<T> = {
+      event: eventName,
+      data: parsed as T,
+      raw: rawEvent,
+    }
+
+    lastEvent.value = payload
+
+    if (listeners.has(eventName)) {
+      for (const listener of listeners.get(eventName)!) {
+        listener(payload)
+      }
+    }
+
+    if (listeners.has('*')) {
+      for (const listener of listeners.get('*')!) {
+        listener(payload)
+      }
+    }
+  }
+
+  function registerHandler(eventName: string): void {
+    if (!eventSource || handlers[eventName]) {
+      return
+    }
+
+    handlers[eventName] = (event) => emitEvent(eventName, event)
+    eventSource.addEventListener(eventName, handlers[eventName] as unknown as EventListener)
+  }
+
+  function unregisterHandler(eventName: string): void {
+    if (!eventSource || !handlers[eventName]) {
+      return
+    }
+
+    eventSource.removeEventListener(eventName, handlers[eventName] as unknown as EventListener)
+    delete handlers[eventName]
+  }
+
+  function connect(): void {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (eventSource) {
+      return
+    }
+
+    const baseUrl = import.meta.env.VITE_PANIC_BASE
+    if (!baseUrl) {
+      console.warn('[panic] VITE_PANIC_BASE is not configured, SSE stream disabled')
+      return
+    }
+
+    const url = `${baseUrl.replace(/\/$/, '')}${STREAM_PATH}`
+    eventSource = new EventSource(url, { withCredentials: true })
+
+    eventSource.onopen = () => {
+      isConnected.value = true
+    }
+
+    eventSource.onerror = (event) => {
+      lastError.value = event
+      isConnected.value = false
+      if (options.immediateReconnect !== false) {
+        disconnect()
+        window.setTimeout(() => connect(), 2500)
+      }
+    }
+
+    handlers.message = (event) => emitEvent('message', event)
+    eventSource.addEventListener('message', handlers.message as unknown as EventListener)
+
+    listeners.forEach((_listenerSet, eventName) => {
+      if (eventName !== 'message') {
+        registerHandler(eventName)
+      }
+    })
+  }
+
+  function disconnect(): void {
+    if (!eventSource) {
+      return
+    }
+
+    Object.keys(handlers).forEach((eventName) => unregisterHandler(eventName))
+    eventSource.close()
+    eventSource = null
+    isConnected.value = false
+  }
+
+  function on<T = unknown>(eventName: string, listener: StreamListener<T>): () => void {
+    if (!listeners.has(eventName)) {
+      listeners.set(eventName, new Set())
+    }
+
+    listeners.get(eventName)!.add(listener as StreamListener<any>)
+
+    if (eventSource) {
+      registerHandler(eventName)
+    }
+
+    return () => {
+      const set = listeners.get(eventName)
+      if (!set) {
+        return
+      }
+
+      set.delete(listener as StreamListener<any>)
+      if (set.size === 0) {
+        listeners.delete(eventName)
+        unregisterHandler(eventName)
+      }
+    }
+  }
+
+  onBeforeUnmount(() => {
+    disconnect()
+  })
+
+  if (options.autoConnect !== false) {
+    connect()
+  }
+
+  return {
+    isConnected,
+    lastEvent,
+    lastError,
+    connect,
+    disconnect,
+    on,
+  }
+}
+
+export function isIncidentEnvelope(payload: unknown): payload is IncidentStreamEnvelope {
+  if (!payload || typeof payload !== 'object') {
+    return false
+  }
+
+  return (
+    'type' in payload &&
+    'payload' in payload &&
+    typeof (payload as IncidentStreamEnvelope).type === 'string'
+  )
+}

--- a/src/composables/useToasts.ts
+++ b/src/composables/useToasts.ts
@@ -1,0 +1,93 @@
+import { computed, reactive } from 'vue'
+
+export type ToastVariant = 'info' | 'success' | 'warning' | 'error'
+
+export interface ToastAction {
+  label: string
+  handler: () => void
+}
+
+export interface ToastOptions {
+  id?: string
+  title?: string
+  message: string
+  variant?: ToastVariant
+  duration?: number | null
+  action?: ToastAction
+}
+
+export interface Toast {
+  id: string
+  title: string
+  message: string
+  variant: ToastVariant
+  action?: ToastAction
+  duration: number | null
+}
+
+const toasts = reactive(new Map<string, Toast>())
+const timeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+function createId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+
+  return Math.random().toString(36).slice(2, 10)
+}
+
+function scheduleRemoval(id: string, duration: number | null): void {
+  if (duration === null) {
+    return
+  }
+
+  const timeoutHandle = timeouts.get(id)
+  if (timeoutHandle) {
+    clearTimeout(timeoutHandle)
+  }
+
+  const timeoutId = setTimeout(() => dismiss(id), duration)
+  timeouts.set(id, timeoutId)
+}
+
+export function push(options: ToastOptions): string {
+  const id = options.id ?? createId()
+
+  const toast: Toast = {
+    id,
+    title: options.title ?? '',
+    message: options.message,
+    variant: options.variant ?? 'info',
+    action: options.action,
+    duration: options.duration ?? 6000,
+  }
+
+  toasts.set(id, toast)
+  scheduleRemoval(id, toast.duration)
+  return id
+}
+
+export function dismiss(id: string): void {
+  const timeoutHandle = timeouts.get(id)
+  if (timeoutHandle) {
+    clearTimeout(timeoutHandle)
+  }
+  timeouts.delete(id)
+  toasts.delete(id)
+}
+
+export function clear(): void {
+  for (const id of Array.from(toasts.keys())) {
+    dismiss(id)
+  }
+  toasts.clear()
+}
+
+export function useToasts() {
+  return {
+    toasts: computed(() => Array.from(toasts.values())),
+    push,
+    dismiss,
+    clear,
+  }
+}

--- a/src/lib/maplibre.ts
+++ b/src/lib/maplibre.ts
@@ -1,0 +1,116 @@
+export interface MapLibreModule {
+  Map: new (options: MapOptions) => MapInstance
+  NavigationControl: new (options?: NavigationOptions) => NavigationControlInstance
+  LngLatBounds: new (sw: [number, number], ne?: [number, number]) => MapBounds
+}
+
+export interface NavigationControlInstance {
+  onAdd: (map: MapInstance) => HTMLElement
+  onRemove: () => void
+}
+
+export interface MapBounds {
+  getSouthWest: () => { lng: number; lat: number }
+  getNorthEast: () => { lng: number; lat: number }
+  toArray: () => [[number, number], [number, number]]
+}
+
+export interface MapInstance {
+  on: (event: string, layerId: string | ((event: any) => void), listener?: (event: any) => void) => void
+  off: (event: string, listener: (event: any) => void) => void
+  addControl: (control: any, position?: string) => void
+  addSource: (id: string, source: any) => void
+  getSource: (id: string) => any
+  addLayer: (layer: any, beforeId?: string) => void
+  setFilter: (layerId: string, filter: any) => void
+  setPaintProperty: (layerId: string, name: string, value: any) => void
+  getLayer: (layerId: string) => any
+  flyTo: (options: any) => void
+  easeTo: (options: any) => void
+  fitBounds: (bounds: any, options?: any) => void
+  getBounds: () => MapBounds
+  project: (lngLat: [number, number]) => { x: number; y: number }
+  resize: () => void
+  remove: () => void
+}
+
+export interface MapOptions {
+  container: HTMLElement | string
+  style: string
+  center?: [number, number]
+  zoom?: number
+  minZoom?: number
+  maxZoom?: number
+  attributionControl?: boolean
+}
+
+export interface NavigationOptions {
+  showCompass?: boolean
+  showZoom?: boolean
+  visualizePitch?: boolean
+}
+
+declare global {
+  interface Window {
+    maplibregl?: MapLibreModule
+  }
+}
+
+const MAPLIBRE_VERSION = '3.6.2'
+const SCRIPT_URL = `https://unpkg.com/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.js`
+const STYLE_URL = `https://unpkg.com/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.css`
+
+let loader: Promise<MapLibreModule> | null = null
+
+function injectScript(): Promise<MapLibreModule> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('MapLibre can only be used in a browser environment'))
+  }
+
+  if (window.maplibregl) {
+    return Promise.resolve(window.maplibregl)
+  }
+
+  if (loader) {
+    return loader
+  }
+
+  injectStyle()
+
+  loader = new Promise<MapLibreModule>((resolve, reject) => {
+    const script = document.createElement('script')
+    script.src = SCRIPT_URL
+    script.async = true
+    script.onload = () => {
+      if (window.maplibregl) {
+        resolve(window.maplibregl)
+      } else {
+        reject(new Error('Failed to initialize MapLibre'))
+      }
+    }
+    script.onerror = () => reject(new Error('Failed to load MapLibre script'))
+    document.head.appendChild(script)
+  })
+
+  return loader
+}
+
+function injectStyle(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  if (document.querySelector('link[data-maplibre-style="true"]')) {
+    return
+  }
+
+  const link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.href = STYLE_URL
+  link.setAttribute('data-maplibre-style', 'true')
+  document.head.appendChild(link)
+}
+
+export async function loadMapLibre(): Promise<MapLibreModule> {
+  return injectScript()
+}

--- a/src/locales/af.json
+++ b/src/locales/af.json
@@ -14,6 +14,7 @@
     "localeRouting": "Taal Roete",
     "safenaboom": "SafeNaboom",
     "storeDemo": "Stoor Demo",
+    "monitor": "Paniek Monitor",
     "profile": "Profiel"
   },
   "auth": {
@@ -207,6 +208,54 @@
       "medium": "Medium",
       "strong": "Sterk"
     }
+  },
+  "monitor": {
+    "title": "Paniek Monitor",
+    "refresh": "Verfris",
+    "loading": "Laai voorvalle…",
+    "retry": "Probeer weer",
+    "close": "Sluit",
+    "acknowledge": "Erken",
+    "resolve": "Los op",
+    "viewOnMap": "Wys op kaart",
+    "acknowledgedToast": "Voorval erken",
+    "resolvedToast": "Voorval opgelos",
+    "actionFailed": "Kon nie die aksie voltooi nie",
+    "lastUpdated": "Opgedateer {time}",
+    "updatedNow": "Nou net",
+    "listCount": "{count} voorvalle",
+    "noIncidents": "Geen voorvalle pas by jou filters nie.",
+    "assignedTo": "Toegeken aan {name}",
+    "filters": {
+      "status": "Status",
+      "dateRange": "Datumreeks",
+      "to": "tot",
+      "search": "Soek",
+      "searchPlaceholder": "Soek na rapporteerders, responders of notas…",
+      "limitToMap": "Beperk tot huidige kaart uitsig",
+      "clear": "Vee filters uit",
+      "refreshWaypoints": "Laai wegpunte weer"
+    },
+    "statuses": {
+      "open": "Oop",
+      "acknowledged": "Erken",
+      "resolved": "Opgelos"
+    },
+    "details": {
+      "reporter": "Rapporteerder",
+      "responder": "Responder",
+      "location": "Ligging"
+    },
+    "activeFilters": {
+      "search": "Gefilter deur \"{query}\""
+    },
+    "sseConnected": "Lewende stroom gekoppel",
+    "sseDisconnected": "Lewende stroom herverbind…",
+    "streamRestored": "Stroom herstel",
+    "streamLost": "Stroom onderbreek",
+    "patrolAlertTitle": "Patrollie alarm",
+    "patrolAlertBodyWithResponder": "{name} het 'n paniek naby {location} geaktiveer",
+    "patrolAlertBody": "Paniek geaktiveer naby {location}"
   },
   "common": {
     "loading": "Laai...",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,6 +14,7 @@
     "localeRouting": "Locale Routing",
     "safenaboom": "SafeNaboom",
     "storeDemo": "Store Demo",
+    "monitor": "Panic Monitor",
     "profile": "Profile"
   },
   "auth": {
@@ -207,6 +208,54 @@
       "medium": "Medium",
       "strong": "Strong"
     }
+  },
+  "monitor": {
+    "title": "Panic Monitor",
+    "refresh": "Refresh",
+    "loading": "Loading incidents…",
+    "retry": "Retry",
+    "close": "Close",
+    "acknowledge": "Acknowledge",
+    "resolve": "Resolve",
+    "viewOnMap": "View on map",
+    "acknowledgedToast": "Incident acknowledged",
+    "resolvedToast": "Incident resolved",
+    "actionFailed": "Could not complete the action",
+    "lastUpdated": "Updated {time}",
+    "updatedNow": "Just now",
+    "listCount": "{count} incidents",
+    "noIncidents": "No incidents match your filters.",
+    "assignedTo": "Assigned to {name}",
+    "filters": {
+      "status": "Status",
+      "dateRange": "Date range",
+      "to": "to",
+      "search": "Search",
+      "searchPlaceholder": "Search reporters, responders or notes…",
+      "limitToMap": "Limit to current map view",
+      "clear": "Clear filters",
+      "refreshWaypoints": "Reload waypoints"
+    },
+    "statuses": {
+      "open": "Open",
+      "acknowledged": "Acknowledged",
+      "resolved": "Resolved"
+    },
+    "details": {
+      "reporter": "Reporter",
+      "responder": "Responder",
+      "location": "Location"
+    },
+    "activeFilters": {
+      "search": "Filtered by \"{query}\""
+    },
+    "sseConnected": "Live stream connected",
+    "sseDisconnected": "Live stream reconnecting…",
+    "streamRestored": "Stream restored",
+    "streamLost": "Stream interrupted",
+    "patrolAlertTitle": "Patrol alert",
+    "patrolAlertBodyWithResponder": "{name} triggered a panic near {location}",
+    "patrolAlertBody": "Panic triggered near {location}"
   },
   "common": {
     "loading": "Loading...",

--- a/src/pages/Monitor.vue
+++ b/src/pages/Monitor.vue
@@ -1,0 +1,949 @@
+<template>
+  <div class="monitor-page">
+    <header class="monitor-header">
+      <div>
+        <h1 class="text-2xl font-semibold text-base-content">{{ t('monitor.title') }}</h1>
+        <p class="text-sm text-base-content/70">
+          {{ lastUpdatedLabel }}
+        </p>
+      </div>
+      <div class="flex items-center gap-3">
+        <span
+          class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium"
+          :class="isStreamConnected ? 'bg-success/10 text-success' : 'bg-warning/10 text-warning'"
+        >
+          <span class="inline-block h-2 w-2 rounded-full" :class="isStreamConnected ? 'bg-success' : 'bg-warning'"></span>
+          {{ connectionLabel }}
+        </span>
+        <button class="btn btn-sm btn-outline" @click="refreshIncidents()" :disabled="loading">
+          {{ t('monitor.refresh') }}
+        </button>
+      </div>
+    </header>
+
+    <section class="monitor-filters">
+      <div class="filter-group">
+        <label class="label-text">{{ t('monitor.filters.status') }}</label>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="option in statusOptions"
+            :key="option.value"
+            class="btn btn-xs"
+            :class="activeStatuses.has(option.value) ? 'btn-primary' : 'btn-outline'"
+            type="button"
+            @click="handleStatusToggle(option.value)"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+      </div>
+
+      <div class="filter-group">
+        <label class="label-text">{{ t('monitor.filters.dateRange') }}</label>
+        <div class="flex flex-wrap items-center gap-2">
+          <input v-model="fromDate" type="date" class="input input-sm input-bordered" />
+          <span class="text-xs text-base-content/60">{{ t('monitor.filters.to') }}</span>
+          <input v-model="toDate" type="date" class="input input-sm input-bordered" />
+        </div>
+      </div>
+
+      <div class="filter-group">
+        <label class="label-text">{{ t('monitor.filters.search') }}</label>
+        <input
+          v-model="searchTerm"
+          type="search"
+          class="input input-sm input-bordered w-full"
+          :placeholder="t('monitor.filters.searchPlaceholder')"
+        />
+      </div>
+
+      <div class="filter-group flex items-center gap-2">
+        <input id="map-filter" v-model="limitToMap" type="checkbox" class="checkbox checkbox-sm" />
+        <label class="label-text cursor-pointer" for="map-filter">
+          {{ t('monitor.filters.limitToMap') }}
+        </label>
+      </div>
+
+      <div class="filter-actions">
+        <button class="btn btn-sm btn-ghost" type="button" @click="clearFilters">
+          {{ t('monitor.filters.clear') }}
+        </button>
+      </div>
+    </section>
+
+    <section class="monitor-content">
+      <div class="incident-list">
+        <header class="list-header">
+          <div>
+            <h2 class="text-lg font-semibold text-base-content">{{ incidentCountLabel }}</h2>
+            <p class="text-xs text-base-content/60" v-if="filters.search">
+              {{ t('monitor.activeFilters.search', { query: filters.search }) }}
+            </p>
+          </div>
+          <button class="btn btn-ghost btn-sm" type="button" @click="incidentStore.loadWaypoints()">
+            {{ t('monitor.filters.refreshWaypoints') }}
+          </button>
+        </header>
+
+        <div class="list-body" :class="loading ? 'opacity-70 pointer-events-none' : ''">
+          <div v-if="loading" class="list-state">
+            <span class="loading loading-spinner" />
+            <span>{{ t('monitor.loading') }}</span>
+          </div>
+
+          <div v-else-if="error" class="list-state text-error">
+            <p>{{ error }}</p>
+            <button class="btn btn-xs btn-outline" type="button" @click="refreshIncidents()">
+              {{ t('monitor.retry') }}
+            </button>
+          </div>
+
+          <ul v-else-if="filteredIncidents.length > 0" class="incident-items">
+            <li v-for="incident in filteredIncidents" :key="incident.id">
+              <button
+                type="button"
+                class="incident-item"
+                :class="selectedIncident?.id === incident.id ? 'incident-item--active' : ''"
+                @click="handleSelectIncident(incident)"
+              >
+                <div class="incident-item__header">
+                  <span class="incident-item__title">{{ incident.summary }}</span>
+                  <span class="badge badge-sm" :class="statusBadgeClass(incident.status)">
+                    {{ statusLabel(incident.status) }}
+                  </span>
+                </div>
+                <div class="incident-item__meta">
+                  <span>{{ formatRelativeTime(incident.reportedAt) }}</span>
+                  <span v-if="incident.priority" class="badge badge-ghost badge-xs">
+                    {{ incident.priority.toUpperCase() }}
+                  </span>
+                </div>
+                <p v-if="incident.description" class="incident-item__description">
+                  {{ incident.description }}
+                </p>
+                <div class="incident-item__footer">
+                  <span v-if="incident.reporter?.name">
+                    {{ incident.reporter.name }}
+                  </span>
+                  <span v-if="incident.responder?.name" class="text-xs text-base-content/60">
+                    {{ t('monitor.assignedTo', { name: incident.responder.name }) }}
+                  </span>
+                </div>
+              </button>
+            </li>
+          </ul>
+
+          <div v-else class="list-state">
+            <p>{{ t('monitor.noIncidents') }}</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="map-pane">
+        <IncidentMap
+          ref="mapRef"
+          :incidents="filteredIncidents"
+          :selected-incident-id="selectedIncident?.id ?? null"
+          :highlight-incident-id="highlightIncidentId"
+          :waypoints="waypoints"
+          @select="handleIncidentSelectedFromMap"
+          @bbox-change="handleBboxChange"
+        />
+      </div>
+    </section>
+
+    <Transition name="drawer">
+      <aside v-if="selectedIncident" class="incident-drawer">
+        <header class="drawer-header">
+          <div>
+            <h2 class="drawer-title">{{ selectedIncident.summary }}</h2>
+            <p class="drawer-subtitle">
+              {{ formatExactTime(selectedIncident.reportedAt) }} · {{ formatRelativeTime(selectedIncident.reportedAt) }}
+            </p>
+          </div>
+          <button class="btn btn-sm btn-ghost" type="button" @click="incidentStore.selectIncident(null)">
+            {{ t('monitor.close') }}
+          </button>
+        </header>
+
+        <section class="drawer-section">
+          <div class="drawer-status">
+            <span class="badge" :class="statusBadgeClass(selectedIncident.status)">
+              {{ statusLabel(selectedIncident.status) }}
+            </span>
+            <span v-if="selectedIncident.priority" class="badge badge-outline">
+              {{ selectedIncident.priority.toUpperCase() }}
+            </span>
+          </div>
+          <p v-if="selectedIncident.description" class="drawer-description">
+            {{ selectedIncident.description }}
+          </p>
+        </section>
+
+        <section class="drawer-section drawer-grid">
+          <div>
+            <h3 class="drawer-heading">{{ t('monitor.details.reporter') }}</h3>
+            <p v-if="selectedIncident.reporter?.name" class="drawer-text">{{ selectedIncident.reporter.name }}</p>
+            <p v-if="selectedIncident.reporter?.phone" class="drawer-text">
+              {{ selectedIncident.reporter.phone }}
+            </p>
+          </div>
+          <div>
+            <h3 class="drawer-heading">{{ t('monitor.details.responder') }}</h3>
+            <p v-if="selectedIncident.responder?.name" class="drawer-text">{{ selectedIncident.responder.name }}</p>
+            <p v-if="selectedIncident.responder?.phone" class="drawer-text">
+              {{ selectedIncident.responder.phone }}
+            </p>
+          </div>
+          <div>
+            <h3 class="drawer-heading">{{ t('monitor.details.location') }}</h3>
+            <p class="drawer-text">
+              {{ formatLocation(selectedIncident) }}
+            </p>
+          </div>
+        </section>
+
+        <footer class="drawer-footer">
+          <div class="flex gap-2">
+            <button
+              class="btn btn-sm btn-outline"
+              type="button"
+              @click="viewSelectedOnMap"
+            >
+              {{ t('monitor.viewOnMap') }}
+            </button>
+            <button
+              class="btn btn-sm btn-primary"
+              type="button"
+              :disabled="!canAcknowledge"
+              @click="selectedIncident && handleAcknowledge(selectedIncident)"
+            >
+              {{ t('monitor.acknowledge') }}
+            </button>
+            <button
+              class="btn btn-sm btn-secondary"
+              type="button"
+              :disabled="!canResolve"
+              @click="selectedIncident && handleResolve(selectedIncident)"
+            >
+              {{ t('monitor.resolve') }}
+            </button>
+          </div>
+        </footer>
+      </aside>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useI18n } from 'vue-i18n'
+import IncidentMap from '@/components/IncidentMap.vue'
+import { useIncidentStore } from '@/stores/incidents'
+import { useIncidentStream, isIncidentEnvelope } from '@/composables/useIncidentStream'
+import { useToasts } from '@/composables/useToasts'
+import { mapIncident } from '@/services/panic'
+import type {
+  Incident,
+  IncidentStatus,
+  IncidentStreamEnvelope,
+  PatrolAlertPayload,
+} from '@/types/panic'
+
+const incidentStore = useIncidentStore()
+const { filteredIncidents, filters, loading, error, lastUpdated, selectedIncident, waypoints, activeStatuses } =
+  storeToRefs(incidentStore)
+
+const { t, locale } = useI18n()
+const { push: pushToast } = useToasts()
+
+const mapRef = ref<InstanceType<typeof IncidentMap> | null>(null)
+const highlightIncidentId = ref<string | null>(null)
+const searchTerm = ref(filters.value.search ?? '')
+const fromDate = ref(filters.value.dateRange.from ?? '')
+const toDate = ref(filters.value.dateRange.to ?? '')
+const limitToMap = ref(false)
+const lastKnownBbox = ref<[number, number, number, number] | null>(filters.value.bbox ?? null)
+
+if (filters.value.bbox) {
+  limitToMap.value = true
+}
+
+const stream = useIncidentStream({ autoConnect: true })
+const isStreamConnected = stream.isConnected
+
+const relativeTimeFormatter = computed(
+  () => new Intl.RelativeTimeFormat(locale.value, { numeric: 'auto' }),
+)
+
+const absoluteTimeFormatter = computed(
+  () => new Intl.DateTimeFormat(locale.value, { dateStyle: 'medium', timeStyle: 'short' }),
+)
+
+const statusOptions = computed(() => [
+  { value: 'open' as IncidentStatus, label: t('monitor.statuses.open') },
+  { value: 'acknowledged' as IncidentStatus, label: t('monitor.statuses.acknowledged') },
+  { value: 'resolved' as IncidentStatus, label: t('monitor.statuses.resolved') },
+])
+
+const incidentCountLabel = computed(() => t('monitor.listCount', { count: filteredIncidents.value.length }))
+const connectionLabel = computed(() =>
+  isStreamConnected.value ? t('monitor.sseConnected') : t('monitor.sseDisconnected'),
+)
+const lastUpdatedLabel = computed(() => {
+  if (!lastUpdated.value) {
+    return t('monitor.loading')
+  }
+  return t('monitor.lastUpdated', { time: formatRelativeTime(lastUpdated.value) })
+})
+
+const canAcknowledge = computed(() => selectedIncident.value?.status === 'open')
+const canResolve = computed(() =>
+  selectedIncident.value?.status === 'open' || selectedIncident.value?.status === 'acknowledged',
+)
+
+let pollingHandle: ReturnType<typeof setInterval> | null = null
+let searchTimer: ReturnType<typeof setTimeout> | null = null
+let dateTimer: ReturnType<typeof setTimeout> | null = null
+let bboxTimer: ReturnType<typeof setTimeout> | null = null
+let highlightTimer: ReturnType<typeof setTimeout> | null = null
+let initialStreamCheck = true
+
+onMounted(async () => {
+  await refreshIncidents()
+  await incidentStore.loadWaypoints()
+  startPolling()
+})
+
+onBeforeUnmount(() => {
+  stopPolling()
+  if (searchTimer) clearTimeout(searchTimer)
+  if (dateTimer) clearTimeout(dateTimer)
+  if (bboxTimer) clearTimeout(bboxTimer)
+  if (highlightTimer) clearTimeout(highlightTimer)
+})
+
+watch(
+  () => filters.value.search,
+  (value) => {
+    if ((value ?? '') !== searchTerm.value) {
+      searchTerm.value = value ?? ''
+    }
+  },
+)
+
+watch(
+  () => filters.value.dateRange.from,
+  (value) => {
+    if ((value ?? '') !== fromDate.value) {
+      fromDate.value = value ?? ''
+    }
+  },
+)
+
+watch(
+  () => filters.value.dateRange.to,
+  (value) => {
+    if ((value ?? '') !== toDate.value) {
+      toDate.value = value ?? ''
+    }
+  },
+)
+
+watch(searchTerm, (value) => {
+  if (searchTimer) {
+    clearTimeout(searchTimer)
+  }
+  searchTimer = setTimeout(() => {
+    incidentStore.setSearch(value)
+  }, 250)
+})
+
+watch(
+  () => [fromDate.value, toDate.value],
+  () => {
+    if (dateTimer) {
+      clearTimeout(dateTimer)
+    }
+    dateTimer = setTimeout(() => {
+      incidentStore.setDateRange(fromDate.value || null, toDate.value || null)
+      refreshIncidents(true)
+    }, 350)
+  },
+)
+
+watch(limitToMap, (enabled) => {
+  if (!enabled) {
+    incidentStore.setBoundingBox(null)
+    refreshIncidents(true)
+    return
+  }
+
+  if (lastKnownBbox.value) {
+    incidentStore.setBoundingBox(lastKnownBbox.value)
+    refreshIncidents(true)
+  }
+})
+
+watch(isStreamConnected, (connected) => {
+  if (initialStreamCheck) {
+    initialStreamCheck = false
+    return
+  }
+
+  pushToast({
+    variant: connected ? 'success' : 'warning',
+    title: connected ? t('monitor.streamRestored') : t('monitor.streamLost'),
+    message: connectionLabel.value,
+  })
+})
+
+stream.on('incident', (event) => {
+  const envelope = normalizeEnvelope(event.data, 'incident')
+  if (!envelope) {
+    return
+  }
+
+  const incident = mapIncident(envelope.payload)
+  incidentStore.upsertIncident(incident)
+})
+
+stream.on('incident_updated', (event) => {
+  const envelope = normalizeEnvelope(event.data, 'incident_updated')
+  if (!envelope) {
+    return
+  }
+  const incident = mapIncident(envelope.payload)
+  incidentStore.upsertIncident(incident)
+})
+
+stream.on('incident_resolved', (event) => {
+  const envelope = normalizeEnvelope(event.data, 'incident_resolved')
+  if (!envelope) {
+    return
+  }
+  const incident = mapIncident(envelope.payload)
+  incidentStore.upsertIncident(incident)
+})
+
+stream.on('incident_removed', (event) => {
+  const envelope = normalizeEnvelope(event.data, 'incident_removed')
+  if (envelope?.payload) {
+    const id = getIncidentId(envelope.payload)
+    if (id) {
+      incidentStore.removeIncident(id)
+    }
+  }
+})
+
+stream.on('patrol_alert', (event) => {
+  const envelope = normalizeEnvelope<PatrolAlertPayload | Incident>(event.data, 'patrol_alert')
+  if (!envelope) {
+    return
+  }
+
+  const payload = envelope.payload
+  const incidentData = isPatrolPayload(payload) ? payload.incident : (payload as Incident)
+  const incident = mapIncident(incidentData)
+  incidentStore.upsertIncident(incident)
+
+  pushToast({
+    variant: 'warning',
+    title: t('monitor.patrolAlertTitle'),
+    message: formatPatrolAlertMessage(incident, payload),
+    action: {
+      label: t('monitor.viewOnMap'),
+      handler: () => {
+        incidentStore.selectIncident(incident.id)
+        focusIncidentOnMap(incident)
+      },
+    },
+  })
+
+  focusIncidentOnMap(incident)
+})
+
+function startPolling() {
+  if (typeof window === 'undefined') {
+    return
+  }
+  stopPolling()
+  pollingHandle = setInterval(() => {
+    refreshIncidents(true)
+  }, 60000)
+}
+
+function stopPolling() {
+  if (pollingHandle) {
+    clearInterval(pollingHandle)
+    pollingHandle = null
+  }
+}
+
+async function refreshIncidents(silent = false) {
+  await incidentStore.fetchIncidents({ silent })
+}
+
+function handleStatusToggle(status: IncidentStatus) {
+  incidentStore.toggleStatus(status)
+  refreshIncidents(true)
+}
+
+function clearFilters() {
+  incidentStore.resetFilters()
+  searchTerm.value = ''
+  fromDate.value = ''
+  toDate.value = ''
+  limitToMap.value = false
+  lastKnownBbox.value = null
+  refreshIncidents()
+}
+
+function handleSelectIncident(incident: Incident) {
+  incidentStore.selectIncident(incident.id)
+  focusIncidentOnMap(incident)
+}
+
+function handleIncidentSelectedFromMap(incidentId: string | null) {
+  incidentStore.selectIncident(incidentId)
+}
+
+function viewSelectedOnMap() {
+  if (!selectedIncident.value) {
+    return
+  }
+  focusIncidentOnMap(selectedIncident.value)
+}
+
+function focusIncidentOnMap(incident: Incident) {
+  nextTick(() => {
+    mapRef.value?.flyToIncident(incident)
+    pulseHighlight(incident.id)
+  })
+}
+
+function handleBboxChange(bbox: [number, number, number, number]) {
+  lastKnownBbox.value = bbox
+  if (!limitToMap.value) {
+    return
+  }
+
+  incidentStore.setBoundingBox(bbox)
+  if (bboxTimer) {
+    clearTimeout(bboxTimer)
+  }
+  bboxTimer = setTimeout(() => {
+    refreshIncidents(true)
+  }, 500)
+}
+
+function pulseHighlight(id: string) {
+  highlightIncidentId.value = id
+  if (highlightTimer) {
+    clearTimeout(highlightTimer)
+  }
+  highlightTimer = setTimeout(() => {
+    if (highlightIncidentId.value === id) {
+      highlightIncidentId.value = null
+    }
+  }, 2200)
+}
+
+async function handleAcknowledge(incident: Incident) {
+  try {
+    await incidentStore.acknowledge(incident.id)
+    pushToast({
+      variant: 'success',
+      title: t('common.success'),
+      message: t('monitor.acknowledgedToast'),
+    })
+  } catch (err) {
+    pushToast({
+      variant: 'error',
+      title: t('monitor.actionFailed'),
+      message: err instanceof Error ? err.message : t('monitor.actionFailed'),
+    })
+  }
+}
+
+async function handleResolve(incident: Incident) {
+  try {
+    await incidentStore.resolve(incident.id)
+    pushToast({
+      variant: 'success',
+      title: t('common.success'),
+      message: t('monitor.resolvedToast'),
+    })
+  } catch (err) {
+    pushToast({
+      variant: 'error',
+      title: t('monitor.actionFailed'),
+      message: err instanceof Error ? err.message : t('monitor.actionFailed'),
+    })
+  }
+}
+
+function statusLabel(status: IncidentStatus) {
+  switch (status) {
+    case 'acknowledged':
+      return t('monitor.statuses.acknowledged')
+    case 'resolved':
+      return t('monitor.statuses.resolved')
+    default:
+      return t('monitor.statuses.open')
+  }
+}
+
+function statusBadgeClass(status: IncidentStatus) {
+  switch (status) {
+    case 'acknowledged':
+      return 'badge-info'
+    case 'resolved':
+      return 'badge-success'
+    default:
+      return 'badge-warning'
+  }
+}
+
+function formatRelativeTime(value: string | Date) {
+  const date = typeof value === 'string' ? new Date(value) : value
+  const diff = date.getTime() - Date.now()
+  const absDiff = Math.abs(diff)
+  const units: [Intl.RelativeTimeFormatUnit, number][] = [
+    ['year', 1000 * 60 * 60 * 24 * 365],
+    ['month', 1000 * 60 * 60 * 24 * 30],
+    ['week', 1000 * 60 * 60 * 24 * 7],
+    ['day', 1000 * 60 * 60 * 24],
+    ['hour', 1000 * 60 * 60],
+    ['minute', 1000 * 60],
+    ['second', 1000],
+  ]
+
+  for (const [unit, unitMs] of units) {
+    if (absDiff >= unitMs || unit === 'second') {
+      const value = Math.round(diff / unitMs)
+      return relativeTimeFormatter.value.format(value, unit)
+    }
+  }
+
+  return t('monitor.updatedNow')
+}
+
+function formatExactTime(value: string | Date) {
+  const date = typeof value === 'string' ? new Date(value) : value
+  return absoluteTimeFormatter.value.format(date)
+}
+
+function formatLocation(incident: Incident) {
+  if (incident.location.address) {
+    return incident.location.address
+  }
+  return `${incident.location.latitude.toFixed(3)}, ${incident.location.longitude.toFixed(3)}`
+}
+
+function formatPatrolAlertMessage(
+  incident: Incident,
+  payload: PatrolAlertPayload | Incident,
+): string {
+  const responderName = isPatrolPayload(payload)
+    ? payload.responder?.name ?? incident.responder?.name
+    : incident.responder?.name
+  const locationLabel = incident.location.address
+    ? incident.location.address
+    : `${incident.location.latitude.toFixed(3)}, ${incident.location.longitude.toFixed(3)}`
+
+  if (responderName) {
+    return t('monitor.patrolAlertBodyWithResponder', {
+      name: responderName,
+      location: locationLabel,
+    })
+  }
+
+  return t('monitor.patrolAlertBody', {
+    location: locationLabel,
+  })
+}
+
+function normalizeEnvelope<T = Incident | PatrolAlertPayload>(
+  value: unknown,
+  fallbackType: string,
+): IncidentStreamEnvelope<T> | null {
+  if (isIncidentEnvelope(value)) {
+    return value as IncidentStreamEnvelope<T>
+  }
+
+  if (!value) {
+    return null
+  }
+
+  return {
+    type: fallbackType,
+    payload: value as T,
+    receivedAt: new Date().toISOString(),
+  }
+}
+
+function getIncidentId(value: unknown): string | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const candidate = (value as any).id ?? (value as any).incidentId ?? (value as any).incident_id
+  return candidate ? String(candidate) : null
+}
+
+function isPatrolPayload(value: unknown): value is PatrolAlertPayload {
+  return Boolean(value && typeof value === 'object' && 'incident' in (value as any))
+}
+</script>
+
+<style scoped>
+.monitor-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  height: 100%;
+  padding: 1.5rem;
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.08), transparent 65%);
+}
+
+.monitor-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.monitor-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  background: var(--color-base-100, #fff);
+  padding: 1rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.05);
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filter-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+}
+
+.monitor-content {
+  display: grid;
+  grid-template-columns: minmax(0, 420px) minmax(0, 1fr);
+  gap: 1.5rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.incident-list {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-base-100, #fff);
+  border-radius: 1rem;
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.list-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+}
+
+.list-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+.incident-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0 0.5rem 0.75rem;
+}
+
+.incident-item {
+  width: 100%;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 0.85rem;
+  border: 1px solid transparent;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.incident-item:hover {
+  border-color: rgba(59, 130, 246, 0.25);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.08);
+}
+
+.incident-item--active {
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 18px 30px rgba(59, 130, 246, 0.18);
+}
+
+.incident-item__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.incident-item__title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--color-base-content, #1f2937);
+}
+
+.incident-item__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.incident-item__description {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.incident-item__footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.map-pane {
+  background: var(--color-base-100, #fff);
+  border-radius: 1rem;
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  position: relative;
+}
+
+.incident-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(420px, 90vw);
+  height: 100%;
+  background: var(--color-base-100, #fff);
+  box-shadow: -10px 0 40px rgba(15, 23, 42, 0.15);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  z-index: 40;
+}
+
+.drawer-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.drawer-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.drawer-subtitle {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.drawer-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.drawer-status {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.drawer-description {
+  font-size: 0.95rem;
+  line-height: 1.45;
+  color: rgba(15, 23, 42, 0.8);
+}
+
+.drawer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.drawer-heading {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.drawer-text {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.8);
+}
+
+.drawer-footer {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.drawer-enter-from,
+.drawer-leave-to {
+  transform: translateX(20px);
+  opacity: 0;
+}
+
+.drawer-enter-active,
+.drawer-leave-active {
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+@media (max-width: 1024px) {
+  .monitor-content {
+    grid-template-columns: 1fr;
+  }
+
+  .incident-list {
+    order: 2;
+  }
+
+  .map-pane {
+    order: 1;
+    min-height: 320px;
+  }
+}
+</style>
+

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -27,6 +27,7 @@ const VuetifyI18nDemo = () => import('@/components/VuetifyI18nDemo.vue')
 const ThemeLocaleSwitcher = () => import('@/components/ThemeLocaleSwitcher.vue')
 const LocaleRoutingDemo = () => import('@/pages/LocaleRoutingDemo.vue')
 const SafeNaboom = () => import('@/pages/SafeNaboom.vue')
+const Monitor = () => import('@/pages/Monitor.vue')
 const StoreDemo = () => import('@/components/StoreDemo.vue')
 const Profile = () => import('@/pages/Profile.vue')
 
@@ -136,6 +137,17 @@ const createLocaleRoutes = (): RouteRecordRaw[] => {
             locale,
             title: 'SafeNaboom',
             description: 'Agricultural community security platform',
+          },
+        },
+        {
+          path: 'monitor',
+          name: `monitor-${locale}`,
+          component: Monitor,
+          meta: {
+            requiresAuth: true,
+            locale,
+            title: 'Panic Monitor',
+            description: 'Live panic and patrol incident monitor',
           },
         },
         {

--- a/src/services/panic.ts
+++ b/src/services/panic.ts
@@ -1,0 +1,221 @@
+import axios from 'axios'
+import type {
+  Incident,
+  IncidentFilters,
+  IncidentPriority,
+  IncidentStatus,
+  Waypoint,
+} from '@/types/panic'
+
+interface IncidentQueryParams {
+  status?: IncidentStatus[]
+  from?: string
+  to?: string
+  bbox?: string
+  search?: string
+}
+
+interface IncidentApiResponse {
+  incidents?: unknown[]
+  data?: unknown[]
+  results?: unknown[]
+  [key: string]: unknown
+}
+
+const DEFAULT_BASE_URL = '/panic/api'
+
+const panicClient = axios.create({
+  baseURL: normalizeBaseUrl(
+    import.meta.env.VITE_PANIC_BASE || `${import.meta.env.VITE_API_BASE || ''}${DEFAULT_BASE_URL}`,
+  ),
+  withCredentials: true,
+  timeout: 20000,
+})
+
+function normalizeBaseUrl(baseUrl?: string): string {
+  if (!baseUrl) {
+    return DEFAULT_BASE_URL
+  }
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+}
+
+function toQueryParams(filters: IncidentFilters): IncidentQueryParams {
+  const params: IncidentQueryParams = {}
+
+  if (filters.statuses.length > 0) {
+    params.status = filters.statuses
+  }
+
+  if (filters.dateRange.from) {
+    params.from = filters.dateRange.from
+  }
+
+  if (filters.dateRange.to) {
+    params.to = filters.dateRange.to
+  }
+
+  if (filters.bbox) {
+    params.bbox = filters.bbox.join(',')
+  }
+
+  if (filters.search && filters.search.trim().length > 0) {
+    params.search = filters.search.trim()
+  }
+
+  return params
+}
+
+function coercePriority(value: unknown): IncidentPriority {
+  if (value === 'low' || value === 'medium' || value === 'high' || value === 'critical') {
+    return value
+  }
+  return 'medium'
+}
+
+function coerceStatus(value: unknown): IncidentStatus {
+  if (value === 'open' || value === 'acknowledged' || value === 'resolved') {
+    return value
+  }
+  return 'open'
+}
+
+function toIncidentId(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number') {
+    return String(value)
+  }
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2, 12)
+}
+
+function safeNumber(value: unknown, fallback: number = 0): number {
+  const result = Number(value)
+  return Number.isFinite(result) ? result : fallback
+}
+
+export function mapIncident(raw: any): Incident {
+  const latitude =
+    raw?.latitude ?? raw?.lat ?? raw?.location?.latitude ?? raw?.location?.lat ?? raw?.location?.y
+  const longitude =
+    raw?.longitude ?? raw?.lon ?? raw?.lng ?? raw?.location?.longitude ?? raw?.location?.lon ?? raw?.location?.x
+
+  return {
+    id: toIncidentId(raw?.id ?? raw?.uuid ?? raw?.incident_id),
+    status: coerceStatus(raw?.status ?? raw?.state),
+    priority: coercePriority(raw?.priority ?? raw?.severity),
+    type: typeof raw?.type === 'string' ? raw.type : 'panic',
+    summary:
+      typeof raw?.summary === 'string'
+        ? raw.summary
+        : typeof raw?.title === 'string'
+          ? raw.title
+          : `Incident ${toIncidentId(raw?.id ?? raw?.uuid ?? raw?.incident_id)}`,
+    description:
+      typeof raw?.description === 'string'
+        ? raw.description
+        : typeof raw?.notes === 'string'
+          ? raw.notes
+          : null,
+    reportedAt: raw?.reportedAt || raw?.reported_at || raw?.createdAt || raw?.created_at || new Date().toISOString(),
+    updatedAt: raw?.updatedAt || raw?.updated_at || raw?.modifiedAt || raw?.modified_at || new Date().toISOString(),
+    location: {
+      latitude: safeNumber(latitude, 0),
+      longitude: safeNumber(longitude, 0),
+      accuracy: raw?.accuracy ?? raw?.location?.accuracy ?? null,
+      address: raw?.address ?? raw?.location?.address ?? null,
+    },
+    reporter: raw?.reporter
+      ? {
+          id: raw.reporter.id ?? raw.reporter.uuid,
+          name: raw.reporter.name ?? raw.reporter.full_name ?? raw.reporter.fullName ?? null,
+          phone: raw.reporter.phone ?? raw.reporter.phone_number ?? null,
+          email: raw.reporter.email ?? null,
+        }
+      : raw?.reporter_name || raw?.reporter_phone
+        ? {
+            name: raw.reporter_name ?? null,
+            phone: raw.reporter_phone ?? null,
+          }
+        : null,
+    responder: raw?.responder
+      ? {
+          id: raw.responder.id ?? raw.responder.uuid,
+          name: raw.responder.name ?? raw.responder.full_name ?? null,
+          phone: raw.responder.phone ?? raw.responder.phone_number ?? null,
+          vehicle: raw.responder.vehicle ?? raw.responder.vehicle_name ?? null,
+        }
+      : null,
+    attachments: Array.isArray(raw?.attachments)
+      ? raw.attachments.filter((value: unknown): value is string => typeof value === 'string')
+      : undefined,
+    metadata: raw?.metadata && typeof raw.metadata === 'object' ? raw.metadata : undefined,
+  }
+}
+
+function extractIncidentList(response: IncidentApiResponse | unknown[]): unknown[] {
+  if (Array.isArray(response)) {
+    return response
+  }
+
+  if (!response || typeof response !== 'object') {
+    return []
+  }
+
+  if (Array.isArray(response.incidents)) {
+    return response.incidents
+  }
+
+  if (Array.isArray(response.data)) {
+    return response.data
+  }
+
+  if (Array.isArray(response.results)) {
+    return response.results
+  }
+
+  return []
+}
+
+export async function fetchIncidents(filters: IncidentFilters): Promise<Incident[]> {
+  const params = toQueryParams(filters)
+  const response = await panicClient.get<IncidentApiResponse | unknown[]>('/incidents', {
+    params,
+  })
+
+  const rawList = extractIncidentList(response.data)
+  return rawList.map((item) => mapIncident(item))
+}
+
+export async function acknowledgeIncident(incidentId: string): Promise<Incident> {
+  const response = await panicClient.post(`/incidents/${incidentId}/ack`, {})
+  return mapIncident(response.data)
+}
+
+export async function resolveIncident(incidentId: string): Promise<Incident> {
+  const response = await panicClient.post(`/incidents/${incidentId}/resolve`, {})
+  return mapIncident(response.data)
+}
+
+export async function fetchWaypoints(): Promise<Waypoint[]> {
+  try {
+    const response = await panicClient.get<{ waypoints?: unknown[]; data?: unknown[] }>('/waypoints')
+    const items = extractIncidentList(response.data as IncidentApiResponse | unknown[])
+    return items
+      .map((item: any) => ({
+        id: toIncidentId(item?.id ?? item?.uuid ?? crypto.randomUUID()),
+        name: typeof item?.name === 'string' ? item.name : `Waypoint ${item?.id ?? ''}`,
+        latitude: safeNumber(item?.latitude ?? item?.lat ?? item?.y, 0),
+        longitude: safeNumber(item?.longitude ?? item?.lon ?? item?.x, 0),
+        radius: item?.radius ?? item?.accuracy ?? null,
+        color: item?.color ?? null,
+      }))
+      .filter((waypoint) => Number.isFinite(waypoint.latitude) && Number.isFinite(waypoint.longitude))
+  } catch (error) {
+    console.warn('[panic] Failed to preload waypoints', error)
+    return []
+  }
+}

--- a/src/stores/incidents.ts
+++ b/src/stores/incidents.ts
@@ -1,0 +1,211 @@
+import { computed, reactive, ref } from 'vue'
+import { defineStore } from 'pinia'
+import {
+  acknowledgeIncident,
+  fetchIncidents as fetchIncidentList,
+  fetchWaypoints,
+  resolveIncident,
+} from '@/services/panic'
+import type {
+  Incident,
+  IncidentFilters,
+  IncidentStatus,
+  Waypoint,
+} from '@/types/panic'
+
+interface FetchOptions {
+  silent?: boolean
+}
+
+const defaultFilters = (): IncidentFilters => ({
+  statuses: [],
+  dateRange: {},
+  bbox: null,
+  search: '',
+})
+
+export const useIncidentStore = defineStore('incident-store', () => {
+  const incidents = ref<Incident[]>([])
+  const filters = reactive<IncidentFilters>(defaultFilters())
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const lastUpdated = ref<Date | null>(null)
+  const selectedIncidentId = ref<string | null>(null)
+  const waypoints = ref<Waypoint[]>([])
+
+  const filteredIncidents = computed(() => {
+    const filterStatuses = new Set(filters.statuses)
+    const fromTs = filters.dateRange.from ? Date.parse(filters.dateRange.from) : null
+    const toTs = filters.dateRange.to ? Date.parse(filters.dateRange.to) : null
+    const term = filters.search?.toLowerCase().trim() || ''
+
+    return incidents.value
+      .filter((incident) => {
+        if (filterStatuses.size > 0 && !filterStatuses.has(incident.status)) {
+          return false
+        }
+
+        const incidentReportedTs = Date.parse(incident.reportedAt)
+        if (Number.isFinite(fromTs) && incidentReportedTs < (fromTs as number)) {
+          return false
+        }
+
+        if (Number.isFinite(toTs) && incidentReportedTs > (toTs as number)) {
+          return false
+        }
+
+        if (term.length > 1) {
+          const haystack = [
+            incident.summary,
+            incident.description,
+            incident.reporter?.name,
+            incident.reporter?.phone,
+            incident.responder?.name,
+            incident.responder?.phone,
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase()
+
+          if (!haystack.includes(term)) {
+            return false
+          }
+        }
+
+        if (filters.bbox) {
+          const [west, south, east, north] = filters.bbox
+          if (
+            incident.location.longitude < west ||
+            incident.location.longitude > east ||
+            incident.location.latitude < south ||
+            incident.location.latitude > north
+          ) {
+            return false
+          }
+        }
+
+        return true
+      })
+      .sort((a, b) => Date.parse(b.reportedAt) - Date.parse(a.reportedAt))
+  })
+
+  const selectedIncident = computed<Incident | null>(() => {
+    if (!selectedIncidentId.value) {
+      return null
+    }
+    return incidents.value.find((incident) => incident.id === selectedIncidentId.value) ?? null
+  })
+
+  const activeStatuses = computed(() => new Set(filters.statuses))
+
+  async function loadWaypoints(): Promise<void> {
+    waypoints.value = await fetchWaypoints()
+  }
+
+  async function fetchIncidents(options: FetchOptions = {}): Promise<void> {
+    if (!options.silent) {
+      loading.value = true
+    }
+    error.value = null
+
+    try {
+      const items = await fetchIncidentList(filters)
+      incidents.value = items
+      lastUpdated.value = new Date()
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : 'Unknown error'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function upsertIncident(incident: Incident): void {
+    const index = incidents.value.findIndex((item) => item.id === incident.id)
+    if (index >= 0) {
+      incidents.value.splice(index, 1, incident)
+    } else {
+      incidents.value.unshift(incident)
+    }
+    lastUpdated.value = new Date()
+  }
+
+  function removeIncident(incidentId: string): void {
+    incidents.value = incidents.value.filter((incident) => incident.id !== incidentId)
+  }
+
+  async function acknowledge(incidentId: string): Promise<Incident> {
+    const updatedIncident = await acknowledgeIncident(incidentId)
+    upsertIncident(updatedIncident)
+    return updatedIncident
+  }
+
+  async function resolve(incidentId: string): Promise<Incident> {
+    const updatedIncident = await resolveIncident(incidentId)
+    upsertIncident(updatedIncident)
+    return updatedIncident
+  }
+
+  function setStatuses(statuses: IncidentStatus[]): void {
+    filters.statuses = [...new Set(statuses)]
+  }
+
+  function toggleStatus(status: IncidentStatus): void {
+    if (filters.statuses.includes(status)) {
+      filters.statuses = filters.statuses.filter((item) => item !== status)
+    } else {
+      filters.statuses = [...filters.statuses, status]
+    }
+  }
+
+  function setDateRange(from: string | null, to: string | null): void {
+    filters.dateRange = {
+      from: from || undefined,
+      to: to || undefined,
+    }
+  }
+
+  function setSearch(term: string): void {
+    filters.search = term
+  }
+
+  function setBoundingBox(bbox: [number, number, number, number] | null): void {
+    filters.bbox = bbox
+  }
+
+  function selectIncident(incidentId: string | null): void {
+    selectedIncidentId.value = incidentId
+  }
+
+  function resetFilters(): void {
+    const defaults = defaultFilters()
+    filters.statuses = defaults.statuses
+    filters.dateRange = defaults.dateRange
+    filters.bbox = defaults.bbox
+    filters.search = defaults.search
+  }
+
+  return {
+    incidents,
+    filters,
+    loading,
+    error,
+    lastUpdated,
+    waypoints,
+    filteredIncidents,
+    selectedIncident,
+    activeStatuses,
+    fetchIncidents,
+    loadWaypoints,
+    upsertIncident,
+    removeIncident,
+    acknowledge,
+    resolve,
+    setStatuses,
+    toggleStatus,
+    setDateRange,
+    setSearch,
+    setBoundingBox,
+    selectIncident,
+    resetFilters,
+  }
+})

--- a/src/types/panic.ts
+++ b/src/types/panic.ts
@@ -1,0 +1,72 @@
+export type IncidentStatus = 'open' | 'acknowledged' | 'resolved'
+
+export type IncidentPriority = 'low' | 'medium' | 'high' | 'critical'
+
+export interface IncidentLocation {
+  latitude: number
+  longitude: number
+  accuracy?: number | null
+  address?: string | null
+}
+
+export interface IncidentReporter {
+  id?: string | number
+  name?: string | null
+  phone?: string | null
+  email?: string | null
+}
+
+export interface IncidentResponder {
+  id?: string | number
+  name?: string | null
+  phone?: string | null
+  vehicle?: string | null
+}
+
+export interface Incident {
+  id: string
+  status: IncidentStatus
+  priority: IncidentPriority
+  type: string
+  summary: string
+  description?: string | null
+  reportedAt: string
+  updatedAt: string
+  location: IncidentLocation
+  reporter?: IncidentReporter | null
+  responder?: IncidentResponder | null
+  attachments?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface IncidentFilters {
+  statuses: IncidentStatus[]
+  dateRange: {
+    from?: string | null
+    to?: string | null
+  }
+  bbox?: [number, number, number, number] | null
+  search?: string
+}
+
+export interface IncidentStreamEnvelope<T = unknown> {
+  id?: string
+  type: string
+  payload: T
+  receivedAt: string
+}
+
+export interface PatrolAlertPayload {
+  incident: Incident
+  note?: string
+  responder?: IncidentResponder | null
+}
+
+export interface Waypoint {
+  id: string
+  name: string
+  latitude: number
+  longitude: number
+  radius?: number | null
+  color?: string | null
+}


### PR DESCRIPTION
## Summary
- add a panic monitor view with filters, SSE-driven updates, incident actions, and toast feedback
- implement MapLibre-backed incident map, CDN loader, panic service/store, and toast composables
- wire navigation, environment typings, and locale strings so the monitor integrates with the existing shell

## Testing
- npm run lint *(fails: ESLint config from @vue/eslint-config-typescript references unsupported `configureVueProject`)*

------
https://chatgpt.com/codex/tasks/task_e_68d11e73f838832cbb2046a13e8ae08c