### PR TITLE
feat: enhance incident map styling

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,19 +1,39 @@
-import { FlatCompat } from '@eslint/eslintrc'
 import js from '@eslint/js'
+import { createConfig as createVueTsConfig } from '@vue/eslint-config-typescript'
+import configPrettier from 'eslint-config-prettier'
+import configPrettierOverrides from 'eslint-config-prettier/prettier'
+import eslintPluginPrettier from 'eslint-plugin-prettier'
+import type { Linter } from 'eslint'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-})
+const vueTsConfig = createVueTsConfig({ rootDir: __dirname })
+const prettierPluginModule = eslintPluginPrettier as { default?: Linter.Plugin }
+const prettierPlugin = prettierPluginModule.default ?? (eslintPluginPrettier as Linter.Plugin)
+
+const basePrettierRules = (configPrettier as { default?: { rules?: Linter.RulesRecord } })
+const overridePrettierRules = (
+  configPrettierOverrides as { default?: { rules?: Linter.RulesRecord } }
+)
+
+const prettierConfig: Linter.FlatConfig = {
+  plugins: {
+    prettier: prettierPlugin,
+  },
+  rules: {
+    ...(basePrettierRules.default?.rules ?? basePrettierRules.rules ?? {}),
+    ...(overridePrettierRules.default?.rules ?? overridePrettierRules.rules ?? {}),
+    'prettier/prettier': 'warn',
+  },
+}
 
 export default [
-  ...compat.extends('@vue/eslint-config-typescript'),
-  ...compat.extends('@vue/eslint-config-prettier'),
+  js.configs.recommended,
+  ...vueTsConfig,
+  prettierConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/src/components/IncidentMap.vue
+++ b/src/components/IncidentMap.vue
@@ -9,6 +9,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import type { StyleSpecification } from 'maplibre-gl'
 import { loadMapLibre, type MapInstance, type MapLibreModule } from '@/lib/maplibre'
 import type { Incident, Waypoint } from '@/types/panic'
 
@@ -52,6 +53,37 @@ const SELECTED_LAYER = 'incident-selected'
 const HIGHLIGHT_LAYER = 'incident-highlight'
 const WAYPOINT_SOURCE = 'waypoint-source'
 const WAYPOINT_LAYER = 'waypoint-circles'
+const WAYPOINT_LABEL_LAYER = 'waypoint-labels'
+
+const FALLBACK_STYLE_URL = 'https://demotiles.maplibre.org/style.json'
+
+interface MapPalette {
+  accent: string
+  accentStrong: string
+  accentSoft: string
+  background: string
+  backgroundMuted: string
+  emphasis: string
+  text: string
+  success: string
+  info: string
+  warning: string
+}
+
+const DEFAULT_PALETTE: MapPalette = {
+  accent: '#2563eb',
+  accentStrong: '#1d4ed8',
+  accentSoft: '#dbeafe',
+  background: '#f8fafc',
+  backgroundMuted: '#e2e8f0',
+  emphasis: '#312e81',
+  text: '#0f172a',
+  success: '#22c55e',
+  info: '#38bdf8',
+  warning: '#f59e0b',
+}
+
+let palette: MapPalette = DEFAULT_PALETTE
 
 const featureCollection = computed(() => buildIncidentCollection(props.incidents))
 const waypointCollection = computed(() => buildWaypointCollection(props.waypoints))
@@ -61,6 +93,8 @@ onMounted(async () => {
     return
   }
 
+  palette = createMapPalette()
+
   try {
     maplibre = await loadMapLibre()
   } catch (error) {
@@ -68,19 +102,37 @@ onMounted(async () => {
     return
   }
 
-  const style = import.meta.env.VITE_MAP_STYLE || 'https://demotiles.maplibre.org/style.json'
+  const styleInput = import.meta.env.VITE_MAP_STYLE || FALLBACK_STYLE_URL
+  const mapStyle = await resolveMapStyle(styleInput, palette)
+
   map.value = new maplibre.Map({
     container: mapContainer.value,
-    style,
+    style: mapStyle,
     center: [28.188, -25.5],
     zoom: 6.5,
     minZoom: 3,
     maxZoom: 18,
+    pitchWithRotate: false,
+    dragRotate: false,
+    touchPitch: false,
+    cooperativeGestures: true,
   })
 
   map.value?.addControl(new maplibre.NavigationControl({ showCompass: false }), 'top-right')
+  map.value?.addControl(new maplibre.FullscreenControl(), 'top-right')
+  map.value?.addControl(
+    new maplibre.GeolocateControl({
+      positionOptions: { enableHighAccuracy: true },
+      trackUserLocation: true,
+      showAccuracyCircle: false,
+      showUserHeading: true,
+    }),
+    'top-left',
+  )
+  map.value?.addControl(new maplibre.ScaleControl({ maxWidth: 140, unit: 'metric' }), 'bottom-left')
 
   map.value?.on('load', () => {
+    applyAtmosphere(map.value as MapInstance, palette)
     setupSources()
     setupLayers()
     bindInteractions()
@@ -166,6 +218,318 @@ function setupSources() {
   }
 }
 
+function createClusterColorExpression() {
+  return [
+    'interpolate',
+    ['linear'],
+    ['get', 'point_count'],
+    0,
+    palette.accentSoft,
+    8,
+    mixHexColors(palette.accent, palette.accentSoft, 0.45, palette.accent),
+    20,
+    palette.accentStrong,
+  ]
+}
+
+function createClusterRadiusExpression() {
+  return ['interpolate', ['linear'], ['get', 'point_count'], 0, 16, 8, 22, 20, 28]
+}
+
+function createPointRadiusExpression() {
+  return ['interpolate', ['linear'], ['zoom'], 4, 7, 10, 10, 16, 16]
+}
+
+function createWaypointRadiusExpression() {
+  return [
+    'case',
+    ['has', 'radius'],
+    ['interpolate', ['linear'], ['zoom'], 6, 8, 12, 16, 16, 22],
+    ['interpolate', ['linear'], ['zoom'], 4, 8, 10, 10, 16, 18],
+  ]
+}
+
+function createStatusColorExpression() {
+  return [
+    'match',
+    ['get', 'status'],
+    'resolved',
+    palette.success,
+    'acknowledged',
+    palette.info,
+    'open',
+    palette.warning,
+    palette.emphasis,
+  ]
+}
+
+function createMapPalette(): MapPalette {
+  if (typeof window === 'undefined') {
+    return DEFAULT_PALETTE
+  }
+
+  const styles = getComputedStyle(document.documentElement)
+  const readColor = (name: string, fallback: string) =>
+    coerceHex(styles.getPropertyValue(name)) ?? fallback
+
+  const background = readColor('--color-base-100', DEFAULT_PALETTE.background)
+  const text = readColor('--color-base-content', DEFAULT_PALETTE.text)
+  const accent = readColor('--color-primary', DEFAULT_PALETTE.accent)
+  const info = readColor('--color-info', DEFAULT_PALETTE.info)
+  const success = readColor('--color-success', DEFAULT_PALETTE.success)
+  const warning = readColor('--color-warning', DEFAULT_PALETTE.warning)
+  const emphasis = readColor('--color-secondary', DEFAULT_PALETTE.emphasis)
+
+  return {
+    accent,
+    accentStrong: mixHexColors(accent, text, 0.25, DEFAULT_PALETTE.accentStrong),
+    accentSoft: mixHexColors(accent, background, 0.65, DEFAULT_PALETTE.accentSoft),
+    background,
+    backgroundMuted: mixHexColors(background, text, 0.08, DEFAULT_PALETTE.backgroundMuted),
+    emphasis,
+    text,
+    success,
+    info,
+    warning,
+  }
+}
+
+async function resolveMapStyle(
+  styleInput: string,
+  theme: MapPalette,
+): Promise<string | StyleSpecification> {
+  if (typeof window === 'undefined') {
+    return styleInput
+  }
+
+  const shouldFetch =
+    styleInput.startsWith('http://') ||
+    styleInput.startsWith('https://') ||
+    styleInput.startsWith('/')
+
+  if (!shouldFetch) {
+    return styleInput
+  }
+
+  try {
+    const resolvedUrl = styleInput.startsWith('http')
+      ? styleInput
+      : new URL(styleInput, window.location.origin).toString()
+    const response = await fetch(resolvedUrl)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch style: ${response.status}`)
+    }
+    const baseStyle = (await response.json()) as StyleSpecification
+    return enhanceBaseStyle(baseStyle, theme)
+  } catch (error) {
+    console.warn('[panic] Unable to fetch enhanced map style, using fallback', error)
+    return styleInput
+  }
+}
+
+function enhanceBaseStyle(style: StyleSpecification, theme: MapPalette): StyleSpecification {
+  const cloned = JSON.parse(JSON.stringify(style)) as StyleSpecification
+  cloned.transition = { duration: 300, delay: 0 }
+  cloned.metadata = { ...(cloned.metadata ?? {}), 'naboomneighbornet:enhanced': true }
+
+  if (Array.isArray(cloned.layers)) {
+    cloned.layers = cloned.layers.map((layer) => {
+      if (!layer) {
+        return layer
+      }
+
+      const nextLayer: Record<string, any> = { ...layer }
+      if (layer.paint) {
+        nextLayer.paint = { ...layer.paint }
+      }
+      if (layer.layout) {
+        nextLayer.layout = { ...layer.layout }
+      }
+
+      const layerId = (layer.id ?? '').toLowerCase()
+
+      if (layer.type === 'background') {
+        nextLayer.paint = nextLayer.paint || {}
+        nextLayer.paint['background-color'] = theme.background
+      }
+
+      if (layer.type === 'fill' && layerId.includes('water')) {
+        nextLayer.paint = nextLayer.paint || {}
+        nextLayer.paint['fill-color'] = mixHexColors(
+          theme.accentSoft,
+          theme.background,
+          0.2,
+          theme.accentSoft,
+        )
+        nextLayer.paint['fill-opacity'] = 0.9
+      }
+
+      if (layer.type === 'fill' && (layerId.includes('landcover') || layerId.includes('park'))) {
+        nextLayer.paint = nextLayer.paint || {}
+        nextLayer.paint['fill-color'] = mixHexColors(
+          theme.success,
+          theme.background,
+          0.7,
+          theme.success,
+        )
+        nextLayer.paint['fill-opacity'] = 0.2
+      }
+
+      if (layer.type === 'fill' && layerId.includes('building')) {
+        nextLayer.paint = nextLayer.paint || {}
+        nextLayer.paint['fill-color'] = mixHexColors(
+          theme.accentSoft,
+          theme.backgroundMuted,
+          0.4,
+          theme.accentSoft,
+        )
+        nextLayer.paint['fill-opacity'] = 0.6
+      }
+
+      if (
+        layer.type === 'line' &&
+        (layerId.includes('road') ||
+          layerId.includes('street') ||
+          layerId.includes('highway') ||
+          layerId.includes('bridge') ||
+          layerId.includes('tunnel'))
+      ) {
+        nextLayer.paint = nextLayer.paint || {}
+        nextLayer.paint['line-color'] = mixHexColors(
+          theme.backgroundMuted,
+          theme.accentSoft,
+          0.35,
+          theme.backgroundMuted,
+        )
+        nextLayer.paint['line-width'] = [
+          'interpolate',
+          ['linear'],
+          ['zoom'],
+          5,
+          0.3,
+          12,
+          1.6,
+          16,
+          3.2,
+        ]
+        nextLayer.layout = nextLayer.layout || {}
+        nextLayer.layout['line-cap'] = 'round'
+        nextLayer.layout['line-join'] = 'round'
+      }
+
+      const hasTextField = Boolean(nextLayer.layout && 'text-field' in nextLayer.layout)
+      if (layer.type === 'symbol' && hasTextField) {
+        nextLayer.paint = nextLayer.paint || {}
+        nextLayer.paint['text-color'] = theme.text
+        nextLayer.paint['text-halo-color'] = colorWithOpacity(theme.background, 0.95)
+        nextLayer.paint['text-halo-width'] = 1.2
+        nextLayer.paint['text-halo-blur'] = 0.4
+
+        nextLayer.layout = nextLayer.layout || {}
+        nextLayer.layout['text-font'] = ['Open Sans SemiBold', 'Arial Unicode MS Bold']
+        nextLayer.layout['text-letter-spacing'] = [
+          'interpolate',
+          ['linear'],
+          ['zoom'],
+          10,
+          0.02,
+          14,
+          0.05,
+        ]
+      }
+
+      return nextLayer
+    })
+  }
+
+  return cloned
+}
+
+function applyAtmosphere(instance: MapInstance, theme: MapPalette) {
+  if (typeof instance.setLight === 'function') {
+    instance.setLight({
+      anchor: 'viewport',
+      color: mixHexColors(theme.backgroundMuted, theme.accentSoft, 0.25, theme.backgroundMuted),
+      intensity: 0.45,
+    })
+  }
+
+  if (typeof instance.setFog === 'function') {
+    instance.setFog({
+      range: [0.5, 8],
+      color: mixHexColors(theme.background, '#cbd5f5', 0.15, theme.background),
+      'high-color': mixHexColors(theme.accentSoft, '#ffffff', 0.35, theme.accentSoft),
+      'space-color': '#020617',
+      'horizon-blend': 0.08,
+    })
+  }
+}
+
+function coerceHex(value: string | null | undefined): string | null {
+  if (!value) {
+    return null
+  }
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  if (/^#?[0-9a-fA-F]{6}$/.test(trimmed)) {
+    return trimmed.startsWith('#') ? trimmed : `#${trimmed}`
+  }
+
+  if (/^#?[0-9a-fA-F]{3}$/.test(trimmed)) {
+    const hex = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed
+    return `#${hex
+      .split('')
+      .map((char) => char.repeat(2))
+      .join('')}`
+  }
+
+  return null
+}
+
+function mixHexColors(colorA: string, colorB: string, ratio: number, fallback?: string): string {
+  const rgbA = hexToRgb(colorA)
+  const rgbB = hexToRgb(colorB)
+
+  if (!rgbA || !rgbB) {
+    return fallback ?? colorA
+  }
+
+  const clampRatio = Math.min(Math.max(ratio, 0), 1)
+  const mixChannel = (index: number) =>
+    Math.round(rgbA[index] * (1 - clampRatio) + rgbB[index] * clampRatio)
+
+  return `#${[mixChannel(0), mixChannel(1), mixChannel(2)]
+    .map((value) => value.toString(16).padStart(2, '0'))
+    .join('')}`
+}
+
+function colorWithOpacity(color: string, alpha: number): string {
+  const rgb = hexToRgb(color)
+  if (!rgb) {
+    return color
+  }
+  const normalizedAlpha = Math.min(Math.max(alpha, 0), 1)
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${normalizedAlpha})`
+}
+
+function hexToRgb(color: string): [number, number, number] | null {
+  const normalized = coerceHex(color)
+  if (!normalized) {
+    return null
+  }
+
+  const hex = normalized.slice(1)
+  if (hex.length !== 6) {
+    return null
+  }
+
+  const value = Number.parseInt(hex, 16)
+  return [(value >> 16) & 255, (value >> 8) & 255, value & 255]
+}
+
 function setupLayers() {
   if (!map.value) {
     return
@@ -178,9 +542,12 @@ function setupLayers() {
       source: INCIDENT_SOURCE,
       filter: ['has', 'point_count'],
       paint: {
-        'circle-color': ['step', ['get', 'point_count'], '#1d4ed8', 5, '#2563eb', 15, '#1e3a8a'],
-        'circle-radius': ['step', ['get', 'point_count'], 14, 5, 18, 15, 22],
-        'circle-opacity': 0.85,
+        'circle-color': createClusterColorExpression(),
+        'circle-radius': createClusterRadiusExpression(),
+        'circle-opacity': 0.88,
+        'circle-stroke-color': palette.background,
+        'circle-stroke-width': 2,
+        'circle-blur': 0.12,
       },
     })
   }
@@ -195,9 +562,12 @@ function setupLayers() {
         'text-field': '{point_count_abbreviated}',
         'text-font': ['Open Sans Bold', 'Arial Unicode MS Bold'],
         'text-size': 12,
+        'text-allow-overlap': true,
       },
       paint: {
-        'text-color': '#ffffff',
+        'text-color': palette.text,
+        'text-halo-color': palette.background,
+        'text-halo-width': 1.2,
       },
     })
   }
@@ -209,20 +579,12 @@ function setupLayers() {
       source: INCIDENT_SOURCE,
       filter: ['!', ['has', 'point_count']],
       paint: {
-        'circle-radius': 9,
+        'circle-radius': createPointRadiusExpression(),
         'circle-stroke-width': 2,
-        'circle-stroke-color': '#ffffff',
-        'circle-color': [
-          'match',
-          ['get', 'status'],
-          'resolved',
-          '#22c55e',
-          'acknowledged',
-          '#38bdf8',
-          'open',
-          '#f97316',
-          '#6366f1',
-        ],
+        'circle-stroke-color': palette.background,
+        'circle-color': createStatusColorExpression(),
+        'circle-opacity': 0.95,
+        'circle-blur': 0.05,
       },
     })
   }
@@ -234,11 +596,12 @@ function setupLayers() {
       source: INCIDENT_SOURCE,
       filter: ['in', ['get', 'id'], ['literal', []]],
       paint: {
-        'circle-radius': 16,
-        'circle-color': '#fbbf24',
-        'circle-opacity': 0.25,
-        'circle-stroke-color': '#f59e0b',
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 4, 16, 10, 22, 16, 28],
+        'circle-color': colorWithOpacity(palette.warning, 0.18),
+        'circle-opacity': 1,
+        'circle-stroke-color': palette.warning,
         'circle-stroke-width': 2,
+        'circle-blur': 0.25,
       },
     })
   }
@@ -250,11 +613,12 @@ function setupLayers() {
       source: INCIDENT_SOURCE,
       filter: ['in', ['get', 'id'], ['literal', []]],
       paint: {
-        'circle-radius': 22,
-        'circle-color': '#fb923c',
-        'circle-opacity': 0.2,
-        'circle-stroke-color': '#f97316',
-        'circle-stroke-width': 1,
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 4, 22, 10, 30, 16, 38],
+        'circle-color': colorWithOpacity(palette.accent, 0.18),
+        'circle-opacity': 1,
+        'circle-stroke-color': palette.accentStrong,
+        'circle-stroke-width': 1.2,
+        'circle-blur': 0.4,
       },
     })
   }
@@ -265,16 +629,35 @@ function setupLayers() {
       type: 'circle',
       source: WAYPOINT_SOURCE,
       paint: {
-        'circle-radius': [
-          'case',
-          ['has', 'radius'],
-          ['interpolate', ['linear'], ['zoom'], 8, 6, 16, 18],
-          8,
-        ],
-        'circle-color': ['coalesce', ['get', 'color'], '#3b82f6'],
-        'circle-opacity': 0.18,
-        'circle-stroke-color': ['coalesce', ['get', 'color'], '#1d4ed8'],
+        'circle-radius': createWaypointRadiusExpression(),
+        'circle-color': colorWithOpacity(palette.info, 0.25),
+        'circle-opacity': 0.9,
+        'circle-stroke-color': palette.info,
         'circle-stroke-width': 2,
+        'circle-blur': 0.15,
+      },
+    })
+  }
+
+  if (!map.value.getLayer(WAYPOINT_LABEL_LAYER)) {
+    map.value.addLayer({
+      id: WAYPOINT_LABEL_LAYER,
+      type: 'symbol',
+      source: WAYPOINT_SOURCE,
+      layout: {
+        'text-field': ['coalesce', ['get', 'name'], ''],
+        'text-font': ['Open Sans Bold', 'Arial Unicode MS Bold'],
+        'text-size': ['interpolate', ['linear'], ['zoom'], 6, 10, 16, 14],
+        'text-offset': [0, 1.3],
+        'text-anchor': 'top',
+        'text-max-width': 10,
+        'text-optional': true,
+      },
+      paint: {
+        'text-color': palette.text,
+        'text-halo-color': colorWithOpacity(palette.background, 0.9),
+        'text-halo-width': 1.1,
+        'text-halo-blur': 0.4,
       },
     })
   }
@@ -521,8 +904,22 @@ defineExpose({ flyToIncident, flashIncident, fitToIncidents, resize })
   position: relative;
   width: 100%;
   height: 100%;
+  min-height: 18rem;
   border-radius: 1rem;
   overflow: hidden;
+  background:
+    radial-gradient(140% 140% at 85% 15%, rgba(59, 130, 246, 0.08), transparent),
+    radial-gradient(120% 120% at 15% 90%, rgba(14, 165, 233, 0.08), transparent),
+    var(--color-base-100, #f8fafc);
+  box-shadow: 0 30px 55px rgba(15, 23, 42, 0.14);
+  transition:
+    box-shadow 200ms ease,
+    transform 200ms ease;
+}
+
+.incident-map:hover {
+  box-shadow: 0 38px 72px rgba(15, 23, 42, 0.18);
+  transform: translateY(-2px);
 }
 
 .map-loader {
@@ -532,8 +929,84 @@ defineExpose({ flyToIncident, flashIncident, fitToIncidents, resize })
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(16, 185, 129, 0.08));
+  gap: 0.85rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(16, 185, 129, 0.12));
   color: var(--color-base-content, #1f2937);
+  backdrop-filter: blur(6px);
+}
+
+:deep(.maplibregl-control-container) {
+  pointer-events: none;
+}
+
+:deep(.maplibregl-ctrl-top-right),
+:deep(.maplibregl-ctrl-top-left),
+:deep(.maplibregl-ctrl-bottom-left) {
+  pointer-events: auto;
+  padding: 0.75rem;
+}
+
+:deep(.maplibregl-ctrl-group) {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
+  background: rgba(248, 250, 252, 0.9);
+  backdrop-filter: blur(8px);
+}
+
+:deep(.maplibregl-ctrl-group button) {
+  width: 2.4rem;
+  height: 2.4rem;
+  border: none;
+  color: var(--color-base-content, #0f172a);
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+:deep(.maplibregl-ctrl-group button:hover),
+:deep(.maplibregl-ctrl-group button:focus-visible) {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-primary, #2563eb);
+}
+
+:deep(.maplibregl-ctrl-scale) {
+  font-family:
+    'Open Sans',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.7);
+  color: #f8fafc;
+  border: none;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
+}
+
+:deep(.maplibregl-user-location-dot),
+:deep(.maplibregl-user-location-accuracy-circle) {
+  transition: transform 200ms ease;
+}
+
+@media (max-width: 960px) {
+  .incident-map {
+    border-radius: 0.85rem;
+    min-height: 16rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .incident-map {
+    border-radius: 0.75rem;
+    min-height: 14rem;
+  }
+
+  :deep(.maplibregl-ctrl-group) {
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.16);
+  }
 }
 </style>

--- a/src/lib/maplibre.ts
+++ b/src/lib/maplibre.ts
@@ -1,4 +1,5 @@
 import maplibregl from 'maplibre-gl'
+import type { StyleSpecification } from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
 // Re-export the module
@@ -8,6 +9,9 @@ export const MapLibreModule = maplibregl
 export interface MapLibreModule {
   Map: new (options: any) => any
   NavigationControl: new (options?: any) => any
+  FullscreenControl: new (options?: any) => any
+  GeolocateControl: new (options?: any) => any
+  ScaleControl: new (options?: any) => any
   LngLatBounds: new (sw: [number, number], ne?: [number, number]) => any
 }
 
@@ -44,16 +48,23 @@ export interface MapInstance {
   resize: () => void
   remove: () => void
   getCanvas: () => HTMLCanvasElement
+  setFog: (fog: any) => void
+  setLight: (light: any) => void
 }
 
 export interface MapOptions {
   container: HTMLElement | string
-  style: string
+  style: string | StyleSpecification
   center?: [number, number]
   zoom?: number
   minZoom?: number
   maxZoom?: number
   attributionControl?: boolean
+  pitch?: number
+  pitchWithRotate?: boolean
+  dragRotate?: boolean
+  touchPitch?: boolean
+  cooperativeGestures?: boolean | Record<string, unknown>
 }
 
 export interface NavigationOptions {


### PR DESCRIPTION
## Summary
- upgrade the incident map to build a themed MapLibre style on load, add responsive controls, waypoint labels, and improved cluster/incident visuals
- extend the MapLibre helper typings to support the new controls, fog/light helpers, and inline style specifications
- refresh the ESLint flat config to consume the Vue TypeScript preset and recreate the Prettier integration without unsupported legacy fields

## Testing
- npm run lint *(fails: existing repository lint rules surface 190 pre-existing errors unrelated to this change)*
- npm run test:unit *(fails: Vitest cannot load Vuetify CSS files in the current test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d1635bf630832ca8963edf1811df4a